### PR TITLE
GPU compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,13 @@ This can be found on the master branch and has the following dependencies:<br>
 [mpi4py](https://mpi4py.readthedocs.io/en/stable/) (if MPI is required)<br>
 
 You can install the requirements and this package with,
+
 ```
-pip install pip install tensorflow-gpu==1.15
+pip install pip install tensorflow==1.15
 pip install git+https://github.com/justinalsing/pydelfi.git
 ```
+(`tensorflow-gpu==1.15` for GPU acceletation instead of `tensorflow==1.15`)
+
 or alternatively, pip install the requirements and then clone the repo and run `python setup.py install`
 
 **Tensorflow 2**

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ You can install the requirements and this package with,
 pip install pip install tensorflow==1.15
 pip install git+https://github.com/justinalsing/pydelfi.git
 ```
-(`tensorflow-gpu==1.15` for GPU acceletation instead of `tensorflow==1.15`)
+(`tensorflow-gpu==1.15` for GPU acceleration instead of `tensorflow==1.15`)
 
 or alternatively, pip install the requirements and then clone the repo and run `python setup.py install`
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ This can be found on the master branch and has the following dependencies:<br>
 
 You can install the requirements and this package with,
 ```
+pip install pip install tensorflow-gpu==1.15
 pip install git+https://github.com/justinalsing/pydelfi.git
 ```
 or alternatively, pip install the requirements and then clone the repo and run `python setup.py install`

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ setup(name='pydelfi',
       url='https://github.com/justinalsing/pydelfi',
       packages=find_packages(),
       install_requires=[
-          "tensorflow >=v1.1.0, <v2.0",
           "getdist",
           "emcee>=v3.0.2",
           "mpi4py",

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,9 @@ setup(name='pydelfi',
           "mpi4py",
           "scipy",
           "tqdm"
-      ])
+      ],
+      extras_require={
+        "tf": ["tensorflow>=v1.1.0, <v2.0"],
+        "tf_gpu": ["tensorflow-gpu>=v1.1.0, <v2.0"]}
+     )
 


### PR DESCRIPTION
The current setup file can block the use of GPUs for training. For example, even with a GPU session on Google Colab, installing with `pip install git+https://github.com/justinalsing/pydelfi.git` means that the GPUs don't get used.

This is a well known issue due to the separation of tf and tf-gpu for tensorflow v1:  [https://github.com/tensorflow/tensorflow/issues/7166](https://github.com/tensorflow/tensorflow/issues/7166). I've implemented the solution from the above [issue](https://github.com/tensorflow/tensorflow/issues/7166): the tf dependencies are not in `install_requires`, but in `extras_require`. 

This solution works. In Google Colab, the following installation for the to-be-merged fork means the GPUs get used in a GPU session:
`!pip install tensorflow-gpu==1.15`
`!pip install git+https://github.com/NiallJeffrey/pydelfi.git`
(also added to the README)

This gives a speed up for my test case of approx x50 - definitely worth it.